### PR TITLE
Add the Moria License

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,6 +263,15 @@
 							https://www.elastic.co/licensing/elastic-license
 						</a>
 					</li>
+					<li>
+						The Moria License<br />
+						<a href="http://free-moria.sourceforge.net/moria-non-free-license.txt" target="_blank">
+							http://free-moria.sourceforge.net/moria-non-free-license.txt
+						</a>
+						(can also be found at <a href="https://web.archive.org/web/19970807075835/http://www.ecst.csuchico.edu/~beej/moria/moria.txt">
+							https://web.archive.org/web/19970807075835/http://www.ecst.csuchico.edu/~beej/moria/moria.txt
+						</a>)
+					</li>
 				</ul>
 			</div>
 


### PR DESCRIPTION
I actually sent an email to the two emails at the bottom of this page, but yeah if you read this license it for sure seems to qualify under the requirements at the top of this page.

Like the Confluent Community License, the license owner (here "Robert Alan Koneke and James E. Wilson") would need to be replaced with the name of the copyright holder.

I'm not sure if I need that "can also be found at" but I don't like that the first URL has "non-free-license" in it's url, and that the 2nd url is soooo long, and includes a lot more than just the license (heck- it's the whole manual)