### PR TITLE
Add Keygen

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,12 @@
 							>
 						</li>
 						<li>
+							Keygen (Elastic License 2.0)<br />
+							<a href="https://github.com/keygen-sh/keygen-api" target="_blank"
+								>Keygen</a
+							>
+						</li>
+						<li>
 							MongoDB (Server Side Public License)<br />
 							<a href="https://github.com/mongodb/mongo" target="_blank"
 								>MongoDB</a


### PR DESCRIPTION
I'm the author of [the Keygen project](https://github.com/keygen-sh/keygen-api), licensed under the ELv2 license as of June 1st, 2023. Before that, Keygen was a closed-source cloud-based SaaS, founded in 2016. I wrote about going open source [here](https://keygen.sh/blog/all-your-licensing-are-belong-to-you/), mentioning https://faircode.io.

Would love to have Keygen included in the fair-code list.