### PR TITLE
Add FSL

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,6 +329,12 @@
 								https://github.com/n8n-io/n8n/blob/master/LICENSE.md
 							</a>
 						</li>
+						<li>
+							Functional Source License<br />
+							<a href="https://fsl.software/" target="_blank"
+								>https://fsl.software/</a
+							>
+						</li>
 					</ul>
 				</div>
 
@@ -422,11 +428,11 @@
 							</a>
 						</li>
 						<li>
-							Sentry (Business Source License)<br />
+							Sentry (Functional Source License)<br />
 							<a href="https://github.com/codecov/self-hosted" target="_blank"
 								>codecov</a
 							>&nbsp;|&nbsp;
-							<a href="https://github.com/getsentry/sentry" target="_blank"
+							<a href="https://github.com/getsentry/self-hosted" target="_blank"
 								>sentry</a
 							>
 						</li>


### PR DESCRIPTION
Greetings! 👋 Sentry and Codecov are now using the [Functional Source License](https://fsl.software/) (FSL), a new license we wrote to clean up the worst parts of the BSL.